### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,6 +11,8 @@ jobs:
   lint-format:
     runs-on: ubuntu-latest
     name: Lint and Format Code
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/divyeshio/commandly/security/code-scanning/7](https://github.com/divyeshio/commandly/security/code-scanning/7)

Add an explicit `permissions` block to the `lint-format` job in `.github/workflows/pr.yml`.

Best fix without changing functionality:
- In the `jobs.lint-format` section, directly under `name` (or under `runs-on`), add:
  - `permissions:`
  - `contents: read`

This is sufficient for checkout and read-only CI checks, documents intended access, and prevents privilege drift if repo/org defaults change. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
